### PR TITLE
Remove BrowserAnimationsModule import from ModalModule

### DIFF
--- a/libs/ui-toolkit/modals/src/lib/modal/modal.module.ts
+++ b/libs/ui-toolkit/modals/src/lib/modal/modal.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatDialogModule } from '@angular/material/dialog';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LoadingModule } from '@gorilainvest/ui-toolkit/loading';
 import { PipesModule } from '@gorilainvest/ui-toolkit/pipes';
 
@@ -9,7 +8,7 @@ import { LoadingModalComponent } from './loading-modal/loading-modal.component';
 import { SimpleModalComponent } from './simple-modal/simple-modal.component';
 
 @NgModule({
-  imports: [CommonModule, MatDialogModule, LoadingModule, PipesModule, BrowserAnimationsModule],
+  imports: [CommonModule, MatDialogModule, LoadingModule, PipesModule],
   declarations: [SimpleModalComponent, LoadingModalComponent],
   exports: [SimpleModalComponent, LoadingModalComponent],
   entryComponents: [SimpleModalComponent, LoadingModalComponent]

--- a/libs/ui-toolkit/modals/src/lib/modal/simple-modal/simple-modal.stories.ts
+++ b/libs/ui-toolkit/modals/src/lib/modal/simple-modal/simple-modal.stories.ts
@@ -1,13 +1,14 @@
 import { Component, Inject, Input, OnChanges, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { PipesModule } from '@gorilainvest/ui-toolkit/pipes';
-import { boolean, text, withKnobs, object } from '@storybook/addon-knobs';
+import { boolean, object, text, withKnobs } from '@storybook/addon-knobs';
 import { moduleMetadata, storiesOf } from '@storybook/angular';
 import { timer } from 'rxjs';
 
-import { SimpleModalData, SocialMediaArray } from './simple-modal.data';
-import { SimpleModalComponent } from './simple-modal.component';
 import { ModalModule } from '../modal.module';
+import { SimpleModalComponent } from './simple-modal.component';
+import { SimpleModalData, SocialMediaArray } from './simple-modal.data';
 
 const socialMediaMock = [
   {
@@ -102,7 +103,7 @@ storiesOf('simple modal', module)
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: [] }
       ],
-      imports: [ModalModule, PipesModule, MatDialogModule],
+      imports: [BrowserAnimationsModule, ModalModule, PipesModule, MatDialogModule],
       declarations: [TestComponent]
     })
   )


### PR DESCRIPTION
`BrowserAnimationsModule` should be imported only once in the App, prefereably in the root module.